### PR TITLE
ENH: Add support for concurrent executions quota.

### DIFF
--- a/aqueduct_client/errors.py
+++ b/aqueduct_client/errors.py
@@ -1,0 +1,23 @@
+class ConcurrentExecutionsExceeded(Exception):
+    """
+    Indicates that the user has tried to launch too many concurrent
+    pipeline executions.
+
+    Attributes
+    ----------
+    current: int
+        The number of executions currently queued or running.
+
+    maximum: int
+        The maximum number of executions that can be queued or running.
+    """
+    def __init__(self, current, maximum):
+        self.current = current
+        self.maximum = maximum
+
+    def __str__(self):
+        return "You have {current} pipeline executions queued or running. " \
+            "The current limit is {maximum}.".format(
+                current=self.current,
+                maximum=self.maximum,
+            )


### PR DESCRIPTION
Adds `get_active_pipeline_executions_info` endpoint, which returns the number of active executions, and the number of allowed active executions.

Adds support for getting HTTP 429 back when submitting a new execution:

```In [3]: aq.submit_pipeline_execution("pass", "2017-01-01", "2017-02-01")
---------------------------------------------------------------------------
ConcurrentExecutionsExceeded              Traceback (most recent call last)
<ipython-input-3-17ffbf32c306> in <module>()
----> 1 aq.submit_pipeline_execution("pass", "2017-01-01", "2017-02-01")

/Users/jean/repo/aqueduct-client/aqueduct_client/aqueduct_client.pyc in submit_pipeline_execution(self, code, start_date, end_date, name, params, asset_identifier_format)
    200             raise ConcurrentExecutionsExceeded(
    201                 data["current"],
--> 202                 data["allowed"],
    203             )
    204         else:

ConcurrentExecutionsExceeded: You have 5 pipeline executions queued or running. The current limit is 5.```