### PR TITLE
ENH: Aqueduct can now handle its own retry loop

### DIFF
--- a/aqueduct_client/errors.py
+++ b/aqueduct_client/errors.py
@@ -21,3 +21,15 @@ class ConcurrentExecutionsExceeded(Exception):
                 current=self.current,
                 maximum=self.maximum,
             )
+
+class PipelineErrorException(Exception):
+    """
+    Indicates that the submitted pipline is in error state
+    """
+    pass
+
+class PipelineInProgressException(Exception):
+    """
+    Indicates that the submitted pipline is in progress
+    """
+    pass

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ def install_requires():
     return [
         'pandas',
         'requests',
+        'tenacity',
     ]
 
 


### PR DESCRIPTION
WIP - I'd love feedback. Added a `client.submit_then_get_pipeline_execution` method to the client that submits a pipeline then handles its own polling loop with timeouts, backoff, jitter, retry, etc. 

- I think we'll have better behaved clients if we give them better defaults to work with 
- @quantopian/black-team wanted to make use of a feature like this in our airflow operator. 

Need to add more documentation, etc, but I think this is good enough to get feedback now. 

Also debating whether `PipelineErrorException` should just call `get_pipeline_execution_error` for you. Unless I'm having network issues or something, I think I'd always want detail on why my pipeline call failed. 

