### PR TITLE
Aqueduct tweaks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ are several ways to use it:
 Usage
 ~~~~~
 
-Note: Fuller documentation will be coming soon.
+Note: Fuller documentation is available at https://factset.quantopian.com/docs/user-guide/tools/aqueduct.
 
 To use ``AqueductClient``, create an instance. In this case, we are loading credentials from disk or environment variable.
 
@@ -46,7 +46,7 @@ To use ``AqueductClient``, create an instance. In this case, we are loading cred
 
   client = create_client()
 
-To run a new pipeline execution, use ``submit_pipeline_execution``.  Required parameters are ``code`` (string), ``start_date`` and ``end_date`` (date-like strings, dates, or Pandas timestamps).  Optional parameters are  ``name`` (string), ``params`` (a dict of parameters to pass to your pipeline), and ``asset_identifier_format`` (which can be "symbol" (default), "sid", and "fsym_region_id").  ``submit_pipeline_execution`` returns an id, which you can pass to ``get_pipeline_execution`` to monitor this pipeline's execution status.
+To run a new pipeline execution, use ``submit_pipeline_execution``.  Required parameters are ``code`` (string), ``start_date`` and ``end_date`` (date-like strings, dates, or Pandas timestamps).  Optional parameters are  ``name`` (string), ``params`` (a dict of parameters to pass to your pipeline), and ``asset_identifier_format`` (which can be "symbol", "sid", and "fsym_region_id").  ``submit_pipeline_execution`` returns an id, which you can pass to ``get_pipeline_execution`` to monitor this pipeline's execution status.
 
 
 ``get_all_pipeline_executions`` and ``get_pipeline_execution(id)`` let you load existing pipelines.  Each pipeline has a ``status`` field, which can be ``IN-PROGRESS``, ``SUCCESS``, or ``FAILED``.

--- a/aqueduct_client/aqueduct_client.py
+++ b/aqueduct_client/aqueduct_client.py
@@ -136,7 +136,7 @@ class AqueductClient(object):
                                   end_date,
                                   name=None,
                                   params=None,
-                                  asset_identifier_format="symbol"):
+                                  asset_identifier_format="sid"):
         """
         Creates and queues a new pipeline execution.
 
@@ -153,7 +153,7 @@ class AqueductClient(object):
         params : dict, optional
             Input arguments for make_pipeline method defined in code.
         asset_identifier_format : str (optional)
-            The type of identifier used to uniquely identify a security.
+            The type of identifier used to identify a security.
             Valid options are "symbol", "sid", or "fsym_region_id".
 
         Returns


### PR DESCRIPTION
Adding links to the new Aqueduct docs and changing the default `asset_identifier_format` to sid, which is guaranteed to be unique and supports global assets. `symbol` and `fsym_region_id` are only supported for `US_EQUITIES` domains.